### PR TITLE
feat: add autoplay option. fix timing issue

### DIFF
--- a/templates/spritesheet.ts
+++ b/templates/spritesheet.ts
@@ -3,10 +3,11 @@ import * as ex from 'excalibur';
 console.log('hello, world');
   
 const resources = {
-    tilemap: new ex.ImageSource('./player-run.png'),
+    spritesheet: new ex.ImageSource('./player-run.png'),
 } as const;
 
-const loader = new ex.Loader(Object.values(resources));
+const loader = new ex.DefaultLoader();
+loader.addResource(resources.spritesheet);
 
 const TILE_SIZE = 96;
 
@@ -19,7 +20,7 @@ const game = new ex.Engine({
 });
 
 const runSheet = ex.SpriteSheet.fromImageSource({
-    image: resources.tilemap,
+    image: resources.spritesheet,
     grid: {
         rows: 1,
         columns: 21,

--- a/templates/tileset.ts
+++ b/templates/tileset.ts
@@ -6,7 +6,8 @@ const resources = {
     tilemap: new ex.ImageSource('./tiny-town/tilemap/tilemap.png'),
 } as const;
 
-const loader = new ex.Loader(Object.values(resources));
+const loader = new ex.DefaultLoader();
+loader.addResource(resources.tilemap);
 
 const TILE_SIZE = 16;
 


### PR DESCRIPTION
=== :clipboard: PR Checklist :clipboard: ===

- [x] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================


Closes #7 

## Changes:

- Adds an autoplay param so embedded playgrounds show something to the user instead of a black screen
- Updates the non-audio templates to skip the play button. I'm envisioning for the embedded playgrounds in the docs to follow a similar pattern? Especially if its not audio or not too intense. 

I have also tried to address a timing issue. I believe its already happening in production, but seems more obvious with autoplay enabled. Occasionally throwing the following "Typescript is not registered". 

We're not the only team to hit this:

 - https://forum.babylonjs.com/t/ts-playground-red-banner-could-not-find-source-file-inmemory-model-1/55126/4?utm_source=chatgpt.com
 - https://github.com/BabylonJS/Babylon.js/pull/11554

If I understand the Babylon playground code, they are retrying? At least the comment suggests that. 

There is an open issue for Monaco Editor, but unfortunately its almost 10 years old. With "waiting skeleton" memes included. https://github.com/microsoft/monaco-editor/issues/115

Regardless, I've added a little exponential backoff that retries the client/worker. Since adding that retry code, it consistently loads. Often between 0 and 2 attempts
